### PR TITLE
🧹 [Code Health] Remove debugger statement in backend/server.mjs

### DIFF
--- a/backend/server.mjs
+++ b/backend/server.mjs
@@ -175,7 +175,6 @@ io.on("connection", socket => {
     "get-logged-on-users",
     (null,
     async user => {
-      debugger;
       console.log("myid", user._id);
       console.log("cache contnents", loggedOnUserCache.get("users"));
       console.log(


### PR DESCRIPTION
🎯 **What:** Removed an accidental `debugger;` statement from `backend/server.mjs`.
💡 **Why:** `debugger;` statements are used for local debugging and shouldn't be committed to the main codebase. They can interrupt execution flow if a debugger is attached and generally degrade code quality.
✅ **Verification:** Verified that the change only removed the single `debugger;` line and didn't affect any surrounding logic. Note: backend currently lacks tests (`npm test` has no configured test script).
✨ **Result:** Improved codebase cleanliness and prevented accidental execution pausing.

---
*PR created automatically by Jules for task [18030315933654731873](https://jules.google.com/task/18030315933654731873) started by @PsytranceIsMyReligion*