### PR TITLE
chore: remove commented out debugger statement

### DIFF
--- a/frontend/src/app/validators/duplicate.staticdata.validator.ts
+++ b/frontend/src/app/validators/duplicate.staticdata.validator.ts
@@ -7,7 +7,6 @@ export function notDuplicateValidator(staticData: Array<StaticData>): ValidatorF
     let includes = staticData
       .map((el: StaticData) => el.name.toLowerCase())
       .includes(control.value.toLowerCase());
-    // debugger;
     return includes ? { duplicate: { value: control.value } } : null;
   };
 }


### PR DESCRIPTION
Removes a commented-out debugger statement from `frontend/src/app/validators/duplicate.staticdata.validator.ts` as requested by the user.

---
*PR created automatically by Jules for task [4024821057686628764](https://jules.google.com/task/4024821057686628764) started by @PsytranceIsMyReligion*