### PR TITLE
Fix: Remove stray debugger statement in get-logged-on-users

### DIFF
--- a/backend/server.mjs
+++ b/backend/server.mjs
@@ -175,7 +175,6 @@ io.on("connection", socket => {
     "get-logged-on-users",
     (null,
     async user => {
-      debugger;
       console.log("myid", user._id);
       console.log("cache contnents", loggedOnUserCache.get("users"));
       console.log(


### PR DESCRIPTION
Remove stray debugger statement in get-logged-on-users socket event handler in backend/server.mjs

---
*PR created automatically by Jules for task [929964760531662619](https://jules.google.com/task/929964760531662619) started by @PsytranceIsMyReligion*