### PR TITLE
🧪 Add unit tests for karmicKudosCheck logic

### DIFF
--- a/backend/models/member.mjs
+++ b/backend/models/member.mjs
@@ -1,5 +1,5 @@
 import mongoose from "mongoose";
-import karmicKudoEmitter from "../utils/events";
+import karmicKudoEmitter from "../utils/events.mjs";
 const Schema = mongoose.Schema;
 
 let MemberSchema = new Schema({

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon --experimental-modules server.mjs",
     "dev-static": "nodemon --experimental-modules static-server.mjs",
     "debug": "nodemon --experimental-modules  --inspect server.mjs",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha \"**/*.spec.*js\""
   },
   "keywords": [],
   "author": "",
@@ -16,10 +16,13 @@
     "@babel/core": "^7.8.4",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.4",
-    "@babel/register": "^7.8.3",
+    "@babel/register": "^7.29.7",
     "babel-preset-env": "^1.7.0",
     "babel-watch": "^7.0.0",
-    "nodemon": "^1.19.4"
+    "chai": "^6.2.2",
+    "mocha": "^11.7.6",
+    "nodemon": "^1.19.4",
+    "sinon": "^22.0.0"
   },
   "dependencies": {
     "@babel/cli": "^7.8.4",

--- a/backend/routes/member.routes.mjs
+++ b/backend/routes/member.routes.mjs
@@ -2,7 +2,7 @@ import express from "express";
 const router = express.Router();
 import mongoose from "mongoose";
 import multer from "multer";
-import Member from "../models/member";
+import Member from "../models/member.mjs";
 import _ from "lodash";
 import nodemailer from "nodemailer";
 import smtpTransport from "nodemailer-smtp-transport";
@@ -204,3 +204,4 @@ async function sendMessage(message) {
 }
 
 export default router;
+export { karmicKudosCheck };

--- a/backend/routes/member.routes.spec.mjs
+++ b/backend/routes/member.routes.spec.mjs
@@ -1,0 +1,79 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import mongoose from "mongoose";
+import { karmicKudosCheck } from "./member.routes.mjs";
+import Member from "../models/member.mjs";
+
+describe("karmicKudosCheck", () => {
+  let member;
+  let updateKarmicKudosStub;
+  let findByIdStub;
+
+  beforeEach(() => {
+    updateKarmicKudosStub = sinon.stub(Member, "updateKarmicKudos");
+    findByIdStub = sinon.stub(Member, "findById");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should assign a new ObjectId to member.referer if referer is not a valid ObjectId", () => {
+    member = { referer: "invalid-id" };
+    karmicKudosCheck(member, false);
+
+    expect(mongoose.Types.ObjectId.isValid(member.referer)).to.be.true;
+    expect(updateKarmicKudosStub.called).to.be.false;
+    expect(findByIdStub.called).to.be.false;
+  });
+
+  it("should update karmic kudos if updateMode is true, member.referer has _id, and checkMember.referer is falsy", () => {
+    const validId = mongoose.Types.ObjectId();
+    const refererId = mongoose.Types.ObjectId();
+    member = { _id: validId, referer: { _id: refererId.toString() } };
+
+    const isValidStub = sinon.stub(mongoose.Types.ObjectId, "isValid").returns(true);
+
+    const mockExec = sinon.stub().yields(null, { referer: null });
+    const mockPopulate = sinon.stub().returns({ exec: mockExec });
+    findByIdStub.returns({ populate: mockPopulate });
+
+    karmicKudosCheck(member, true);
+
+    expect(isValidStub.calledOnce).to.be.true;
+    expect(findByIdStub.calledOnceWith(member._id)).to.be.true;
+    expect(mockPopulate.calledOnceWith("referer")).to.be.true;
+    expect(mockExec.calledOnce).to.be.true;
+    expect(updateKarmicKudosStub.calledOnceWith(member.referer, 10)).to.be.true;
+  });
+
+  it("should not update karmic kudos if updateMode is true, member.referer has _id, but checkMember.referer is truthy", () => {
+    const validId = mongoose.Types.ObjectId();
+    const refererId = mongoose.Types.ObjectId();
+    member = { _id: validId, referer: { _id: refererId.toString() } };
+
+    const isValidStub = sinon.stub(mongoose.Types.ObjectId, "isValid").returns(true);
+
+    const mockExec = sinon.stub().yields(null, { referer: "some-referer" });
+    const mockPopulate = sinon.stub().returns({ exec: mockExec });
+    findByIdStub.returns({ populate: mockPopulate });
+
+    karmicKudosCheck(member, true);
+
+    expect(isValidStub.calledOnce).to.be.true;
+    expect(findByIdStub.calledOnceWith(member._id)).to.be.true;
+    expect(mockPopulate.calledOnceWith("referer")).to.be.true;
+    expect(mockExec.calledOnce).to.be.true;
+    expect(updateKarmicKudosStub.called).to.be.false;
+  });
+
+  it("should update karmic kudos if updateMode is false and member.referer is a valid ObjectId", () => {
+    const refererId = mongoose.Types.ObjectId();
+    member = { referer: refererId };
+
+    karmicKudosCheck(member, false);
+
+    expect(findByIdStub.called).to.be.false;
+    expect(updateKarmicKudosStub.calledOnceWith(member.referer, 10)).to.be.true;
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `karmicKudosCheck` function in `backend/routes/member.routes.mjs` lacked test coverage. This is a critical business logic path responsible for giving "karmic kudos" to members referring others to the platform.

📊 **Coverage:** What scenarios are now tested
The new `member.routes.spec.mjs` covers all execution paths for `karmicKudosCheck`:
- Invalid ObjectIds assigned to `member.referer`
- Updating kudos when `updateMode` is true, `member.referer` has `_id`, and `checkMember.referer` is falsy
- Not updating kudos when `updateMode` is true, `member.referer` has `_id`, and `checkMember.referer` is truthy
- Updating kudos when `updateMode` is false and `member.referer` is valid.

✨ **Result:** The improvement in test coverage
`karmicKudosCheck` logic is now fully tested by using Sinon to mock `mongoose` and `Member` operations. The backend `npm test` script has also been correctly set up to execute Mocha against any `.spec.js` and `.spec.mjs` files without regressions. Cleaned up missing module extensions (`.mjs`) on local imports in the codebase to make it compatible with the Node ES modules resolver.

---
*PR created automatically by Jules for task [8874913729970894742](https://jules.google.com/task/8874913729970894742) started by @PsytranceIsMyReligion*