### PR TITLE
🧹 Remove commented out code in MemberService

### DIFF
--- a/frontend/src/app/services/member.service.ts
+++ b/frontend/src/app/services/member.service.ts
@@ -149,9 +149,6 @@ export class MemberService implements OnInit {
       });
       console.log("get lgd on", this.user$.getValue());
       this.socket.emit("get-logged-on-users", this.user$.getValue());
-      // setTimeout(() => {
-      //   this.socket.emit("get-logged-on-users", this.user$.getValue());
-      // });
     });
   }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a commented out setTimeout block that added unnecessary noise.
💡 **Why:** Removing dead commented out code improves maintainability and makes it easier for future developers to reason about the service.
✅ **Verification:** Ran `npm test -- --watch=false --browsers=ChromeHeadless` in the frontend directory with the openssl legacy provider flag and all tests passed successfully.
✨ **Result:** A cleaner service file devoid of unused comments.

---
*PR created automatically by Jules for task [1926786380967733309](https://jules.google.com/task/1926786380967733309) started by @PsytranceIsMyReligion*